### PR TITLE
add hippunfold gh/dh to apps

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -110,3 +110,5 @@ apps:
     dh: 'peerherholz/bidsonym'
   - gh: 'Medical-Image-Analysis-Laboratory/mialsuperresolutiontoolkit'
     dh: 'sebastientourbier/mialsuperresolutiontoolkit'
+  - gh: 'khanlab/hippunfold'
+    dh: 'khanlab/hippunfold'


### PR DESCRIPTION
This PR adds khanlab/hippunfold to the list of apps.

Dockerhub: khanlab/hippunfold:v0.4.1
Github: https://github.com/khanlab/hippunfold
Readthedocs: https://hippunfold.readthedocs.io/en/latest/

Thanks!
Ali