### PR TITLE
add micapipe to BIDS Apps

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -112,3 +112,5 @@ apps:
     dh: 'sebastientourbier/mialsuperresolutiontoolkit'
   - gh: 'khanlab/hippunfold'
     dh: 'khanlab/hippunfold'
+  - gh: 'MICA-MNI/micapipe'
+    dh: 'micalab/micapipe'


### PR DESCRIPTION
This PR adds [micapipe](http://micapipe.readthedocs.io/) to the list of available BIDS Apps. The `github repo` can be found [here](https://github.com/MICA-MNI/micapipe) and the container on `docker hub` [here](https://hub.docker.com/r/micalab/micapipe).

TL;DR (copied from the docs): Micapipe is a processing pipeline providing a robust framework to analyze multimodal MRI data. This pipeline integrates processing streams for T1-weighted, microstructure-sensitive, diffusion-weighted, and resting-state functional imaging to facilitate the development of multiscale models of neural organization. For this purpose, we leverage several specialized software packages to bring BIDS-formatted raw MRI data to fully-processed surface-based feature matrices.