### PR TITLE
Adds funcmasker-flex bids app

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -145,6 +145,9 @@ apps:
   # apps hosted somewhere else
   # sorted alphabetically by DockerHub (dh)
 
+  - gh: 'khanlab/funcmasker-flex'
+    dh: 'khanlab/funcmasker-flex'
+
   - gh: "khanlab/hippunfold"
     dh: "khanlab/hippunfold"
 


### PR DESCRIPTION
Hello!

This PR adds our snakebids app for fetal bold u-net brain masking, [funcmasker-flex](https://github.com/khanlab/funcmasker-flex) (to be presented at OHBM 2022) to the list of BIDS Apps. 

Thanks!
Ali