### PR TITLE
mod gift-bids pointing to github (https://github.com/trendscenter/gif…

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -187,5 +187,5 @@ apps:
   - gh: "Medical-Image-Analysis-Laboratory/mialsuperresolutiontoolkit"
     dh: "sebastientourbier/mialsuperresolutiontoolkit"
 
-  - gh: "TReNDS/gift-bids"
-    dh: "trends/gift-bids"
+  - gh: "trendscenter/gift-bids"
+    dh: "trendscenter/gift-bids"


### PR DESCRIPTION
@sappelhoff @Remi-Gau. Apologize, but yesterday I pointed the _config.yaml to Docker, seeing now it should point to our github! May you apply this mod to correct this? Additional info github=https://github.com/trendscenter/gift-bids,  dockerhub=https://hub.docker.com/r/trends/gift-bids