### PR TITLE
I found giga_connectome only in hationgwang space

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -180,7 +180,7 @@ apps:
 
 -   gh: bids-apps/giga_connectome
     status: active
-    dh: bids/giga_connectome
+    dh: haotingwang/giga_connectome
     ci: gh
     branch: main
     workflow: test


### PR DESCRIPTION
May be it is yet to come to bids on docker hub?

was added in https://github.com/bids-apps/bids-apps.github.io/pull/120

attn @Remi-Gau 