### PR TITLE
Add QSIRecon and fMRIPost apps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,6 @@ repos:
         args: [--mapping, '4', --sequence, '4', --offset, '0']
 
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
     -   id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,6 @@ repos:
         args: [--mapping, '4', --sequence, '4', --offset, '0']
 
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.8.0
+    rev: 24.4.2
     hooks:
     -   id: black

--- a/_config.yml
+++ b/_config.yml
@@ -503,7 +503,7 @@ apps:
 
 -   gh: ME-ICA/fmripost-tedana
     status: active
-    dh: me-ica/fmripost-tedana
+    dh: tedana/fmripost-tedana
     ds_type:
     -   derivative
     datatype:

--- a/_config.yml
+++ b/_config.yml
@@ -501,15 +501,6 @@ apps:
     -   func
     description: Functional MRI postprocessing with Rapidtide
 
--   gh: ME-ICA/fmripost-tedana
-    status: active
-    dh: tedana/fmripost-tedana
-    ds_type:
-    -   derivative
-    datatype:
-    -   func
-    description: Multi-echo fMRI postprocessing with tedana
-
 -   gh: PeerHerholz/BIDSonym
     status: active
     dh: peerherholz/bidsonym

--- a/_config.yml
+++ b/_config.yml
@@ -474,6 +474,42 @@ apps:
     -   raw
     description: Structural MRI PREProcessing (sMRIPrep) workflows for NIPreps (NeuroImaging PREProcessing tools)
 
+-   gh: nipreps/fmripost-aroma
+    status: active
+    dh: nipreps/fmripost-aroma
+    ds_type:
+    -   derivative
+    datatype:
+    -   func
+    description: Functional MRI postprocessing with ICA-AROMA
+
+-   gh: nipreps/fmripost-phase
+    status: active
+    dh: nipreps/fmripost-phase
+    ds_type:
+    -   derivative
+    datatype:
+    -   func
+    description: Postprocessing of complex-valued fMRI data
+
+-   gh: nipreps/fmripost-rapidtide
+    status: active
+    dh: nipreps/fmripost-rapidtide
+    ds_type:
+    -   derivative
+    datatype:
+    -   func
+    description: Functional MRI postprocessing with Rapidtide
+
+-   gh: ME-ICA/fmripost-tedana
+    status: active
+    dh: me-ica/fmripost-tedana
+    ds_type:
+    -   derivative
+    datatype:
+    -   func
+    description: Multi-echo fMRI postprocessing with tedana
+
 -   gh: PeerHerholz/BIDSonym
     status: active
     dh: peerherholz/bidsonym
@@ -514,9 +550,20 @@ apps:
     -   raw
     datatype:
     -   dwi
-    description: Preprocessing and reconstruction of diffusion MRI
+    description: Preprocessing of diffusion MRI
     ci: circleci
     branch: master
+
+-   gh: PennLINC/qsirecon
+    status: active
+    dh: pennlinc/qsirecon
+    ds_type:
+    -   derivative
+    datatype:
+    -   dwi
+    description: Reconstruction of preprocessed diffusion MRI
+    ci: circleci
+    branch: main
 
 -   gh: poldracklab/fitlins
     status: active


### PR DESCRIPTION
We recently split QSIPrep into [`QSIPrep`](https://github.com/PennLINC/qsiprep) (just preprocessing) and [`QSIRecon`](https://github.com/PennLINC/qsirecon) (just reconstruction).

I've also been working on fMRIPost apps: [`fMRIPost-AROMA`](https://github.com/nipreps/fmripost-aroma), [`fMRIPost-Phase`](https://github.com/nipreps/fmripost-phase), [`fMRIPost-Rapidtide`](https://github.com/nipreps/fmripost-rapidtide), and [`fMRIPost-tedana`](https://github.com/ME-ICA/fmripost-tedana). fMRIPost-AROMA is the only one that is currently up and running, so I can remove the others if we only want to document working Apps.

EDIT: I dropped fMRIPost-tedana from the list because it doesn't have a DockerHub repo yet.